### PR TITLE
Ckan 2.3a

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,11 @@ This extension is meant to add a few pages that will add a friendly interface
 to talk to the action API. Install the extension and visit `/apihelper/`.
 Requires CKAN Version 2.1.1 or higher.
 
+## Installation
+Clone the repo, install it with `python setup.py develop` or `pip install -e .`,
+and add the following to your ckan.ini:
+```
+ckan.plugins = ... apihelper
+```
+
 ![](http://okfnlabs.org/ckanext-apihelper/api-helper.png)

--- a/ckanext/apihelper/extract.py
+++ b/ckanext/apihelper/extract.py
@@ -59,6 +59,5 @@ def extract_actions():
                 if (hasattr(v, '__call__')
                         and (v.__module__ == module_path
                              or hasattr(v, '__replaced'))):
-                    k = new_authz.clean_action_name(k)
                     actions[action_module_name][k] = get_doc(k)
     return actions


### PR DESCRIPTION
- Removes a no longer existent function call, to be compatible with ckan master
- Small addition to the readme
